### PR TITLE
set input box-sizing to content-box

### DIFF
--- a/src/json-map/keyValuePair.vue
+++ b/src/json-map/keyValuePair.vue
@@ -174,6 +174,7 @@
         background-color: transparent;
         color: #2E7D32;
         transition: width, background-color 0.15s linear;
+        box-sizing: content-box;
     }
 
     div.fixed_label {


### PR DESCRIPTION
if the inputs somehow get set to `border-box` (e.g: I had a `* { box-sizing: border-box; }` rule) the width calculation would be off, because the `span#sp` element which is used for measurements doesn't have a padding.